### PR TITLE
disable annotation on video

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,8 @@ class YoutubeBackground extends React.Component {
 				controls: 0,
 				rel: 0,
 				showinfo: 0,
-				mute:1
+				mute:1,
+				iv_load_policy: 3
 			}
 		};
 


### PR DESCRIPTION
setting iv_load_policy to 3 to do not show annotation by default

see https://developers.google.com/youtube/player_parameters#iv_load_policy