### PR TITLE
remove div that is not stylable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ class YoutubeBackground extends React.Component {
 
 		return (
 			<div style={style} ref={c => this.container = c} className={[styles.container, className].join(' ')}>
-				<div>{children}</div>
+				<>{children}</>
 				<div
 					className={styles.videoContainer}
 					style={{


### PR DESCRIPTION
Hey,

I just found your repo and want to use it without forking.

I found that I can't style it as much as I want and it's because there is a div that is not stylable with your current API.

Changing it to React Fragment make children prop render without this empty div.

Thanks!

P.S. tabs 😭